### PR TITLE
Add Calico as a Networking option, a few other goodies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,13 @@ data "template_file" "core-init" {
   template = "${file("${format("%s/scripts/k8s-core.sh.tpl", path.module)}")}"
 
   vars {
-    dns_ip          = "${var.dns_ip}"
-    docker_version  = "${var.docker_version}"
-    k8s_version     = "${var.k8s_version}"
-    cni_version     = "${var.cni_version}"
-    tags            = "${random_id.instance-prefix.hex}"
-    instance_prefix = "${random_id.instance-prefix.hex}"
-    pod_network_type  = "${var.pod_network_type}"
+    dns_ip           = "${var.dns_ip}"
+    docker_version   = "${var.docker_version}"
+    k8s_version      = "${var.k8s_version}"
+    cni_version      = "${var.cni_version}"
+    tags             = "${random_id.instance-prefix.hex}"
+    instance_prefix  = "${random_id.instance-prefix.hex}"
+    pod_network_type = "${var.pod_network_type}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,7 @@ data "template_file" "core-init" {
     cni_version     = "${var.cni_version}"
     tags            = "${random_id.instance-prefix.hex}"
     instance_prefix = "${random_id.instance-prefix.hex}"
+    pod_network_type  = "${var.pod_network_type}"
   }
 }
 
@@ -17,11 +18,13 @@ data "template_file" "master-bootstrap" {
   vars {
     k8s_version       = "${var.k8s_version}"
     dashboard_version = "${var.dashboard_version}"
+    calico_version    = "${var.calico_version}"
     pod_cidr          = "${var.pod_cidr}"
     service_cidr      = "${var.service_cidr}"
     token             = "${random_id.token-part-1.hex}.${random_id.token-part-2.hex}"
     cluster_uid       = "${var.cluster_uid == "" ? random_id.cluster-uid.hex : var.cluster_uid}"
     instance_prefix   = "${random_id.instance-prefix.hex}"
+    pod_network_type  = "${var.pod_network_type}"
   }
 }
 

--- a/scripts/k8s-core.sh.tpl
+++ b/scripts/k8s-core.sh.tpl
@@ -21,10 +21,15 @@ sudo apt-get install -y \
   kubectl=${k8s_version}* \
   kubernetes-cni=${cni_version}*
 
+network_plugin=kubenet
+if [ "${pod_network_type}" == "calico" ]; then
+  network_plugin=cni
+fi
+
 # Drop in config for kubenet and cloud provider
 cat >/etc/systemd/system/kubelet.service.d/20-gcenet.conf <<EOF
 [Service]
-Environment="KUBELET_NETWORK_ARGS=--network-plugin=kubenet --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
+Environment="KUBELET_NETWORK_ARGS=--network-plugin=$${network_plugin} --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=${dns_ip} --cluster-domain=cluster.local"
 Environment="KUBELET_EXTRA_ARGS=--cloud-provider=gce"
 EOF

--- a/scripts/master.sh.tpl
+++ b/scripts/master.sh.tpl
@@ -27,8 +27,15 @@ chmod 0600 /etc/kubernetes/kubeadm.conf
 
 kubeadm init --config /etc/kubernetes/kubeadm.conf
 
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+if [ "${pod_network_type}" == "calico" ]; then
+  kubectl apply -f https://docs.projectcalico.org/v${calico_version}/getting-started/kubernetes/installation/hosted/rbac-kdd.yaml
+  kubectl apply -f https://docs.projectcalico.org/v${calico_version}/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+fi
+
 # kubeadm manages the manifests directory, so add configmap after the init returns.
-kubectl --kubeconfig /etc/kubernetes/admin.conf create -f - <<'EOF'
+kubectl create -f - <<'EOF'
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -42,7 +49,7 @@ EOF
 # Install L7 GLBC controller, path glbc.manifest to support kubeadm cluster.
 curl -sL https://raw.githubusercontent.com/kubernetes/kubernetes/v${k8s_version}/cluster/saltbase/salt/l7-gcp/glbc.manifest | \
   sed \
-    -e 's|--apiserver-host=http://localhost:8080|--apiserver-host=https://127.0.0.1:6443 --kubeconfig=/etc/kubernetes/admin.conf|g' \
+    -e 's|--apiserver-host=http://localhost:8080|--apiserver-host=https://127.0.0.1:6443|g' \
     -e 's|--config-file-path=/etc/gce.conf|--config-file-path=/etc/kubernetes/gce.conf|g' \
     -e 's|: /etc/gce.conf|: /etc/kubernetes|g' \
     > /etc/kubernetes/manifests/glbc.manifest
@@ -50,12 +57,12 @@ chmod 0600 /etc/kubernetes/manifests/glbc.manifest
 
 # Install default http-backend controller
 curl -sL https://raw.githubusercontent.com/kubernetes/kubernetes/v${k8s_version}/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml | \
-  kubectl --kubeconfig /etc/kubernetes/admin.conf create -n kube-system -f -
+  kubectl create -n kube-system -f -
 
 # Install default http-backend service
 curl -sL https://raw.githubusercontent.com/kubernetes/kubernetes/v${k8s_version}/cluster/addons/cluster-loadbalancing/glbc/default-svc.yaml | \
-  kubectl --kubeconfig /etc/kubernetes/admin.conf create -n kube-system -f -
+  kubectl create -n kube-system -f -
 
 # Install dashboard addon
 curl -sL https://raw.githubusercontent.com/kubernetes/dashboard/${dashboard_version}/src/deploy/kubernetes-dashboard.yaml |
-  kubectl --kubeconfig /etc/kubernetes/admin.conf create -n kube-system -f -
+  kubectl create -n kube-system -f -

--- a/scripts/master.sh.tpl
+++ b/scripts/master.sh.tpl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 cat <<EOF > /etc/kubernetes/kubeadm.conf
 apiVersion: kubeadm.k8s.io/v1alpha1

--- a/scripts/node.sh.tpl
+++ b/scripts/node.sh.tpl
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/bash -xe
 
 kubeadm join --token=${token} ${master_ip}:6443

--- a/variables.tf
+++ b/variables.tf
@@ -96,17 +96,17 @@ variable master_ip {
 
 variable pod_cidr {
   description = "The CIDR for the pod network. The master will allocate a portion of this subnet for each node."
-  default     = "10.40.0.0/14"
+  default     = "192.168.0.0/16"
 }
 
 variable service_cidr {
   description = "The CIDR for the service network"
-  default     = "10.25.240.0/20"
+  default     = "10.96.0.0/12"
 }
 
 variable dns_ip {
   description = "The IP of the kube DNS service, must live within the service_cidr."
-  default     = "10.25.240.10"
+  default     = "10.96.0.10"
 }
 
 variable depends_id {

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable docker_version {
   default     = "17.06.0"
 }
 
+variable calico_version {
+  description = "Version of Calico to install for pod networking."
+  default     = "2.4"
+}
+
 variable compute_image {
   description = "The project/image to use on the master and nodes. Must be ubuntu or debian 8+ compatible."
   default     = "ubuntu-os-cloud/ubuntu-1704"
@@ -35,6 +40,11 @@ variable compute_image {
 variable network {
   description = "The network to deploy to"
   default     = "default"
+}
+
+variable pod_network_type {
+  description = "The type of networking to use for inter-pod traffic. Either kubenet or calico."
+  default     = "kubenet"
 }
 
 variable subnetwork {

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable cluster_uid {
 
 variable k8s_version {
   description = "The version of kubernetes to use. See available versions using: `apt-cache madison kubelet`"
-  default     = "1.7.3"
+  default     = "1.7.4"
 }
 
 variable dashboard_version {


### PR DESCRIPTION
1. Ensure all init scripts have -xe
2. Add Calico as an option for pod/service networking
3. Update to K8s 1.7.4
4. CIDRs that are compatible with Calico (for some reason these are hardcoded somewhere, should still work for kubenet though)
5. Use env var for kubeconfig location in master init script

Happy to revert any commit you dont like.